### PR TITLE
fix double-promotions

### DIFF
--- a/SensorsSDK/WSEN_PADS_2511020213301/WSEN_PADS_2511020213301.c
+++ b/SensorsSDK/WSEN_PADS_2511020213301/WSEN_PADS_2511020213301.c
@@ -2142,7 +2142,7 @@ float PADS_convertPressure_float(int32_t rawPres)
  */
 float PADS_convertDifferentialPressure_float(int32_t rawPres)
 {
-  return ((float) rawPres) * 0.00625;
+  return ((float) rawPres) * 0.00625f;
 }
 
 #endif /* WE_USE_FLOAT */

--- a/SensorsSDK/WSEN_PDUS_25131308XXX01/WSEN_PDUS_25131308XXX01.c
+++ b/SensorsSDK/WSEN_PDUS_25131308XXX01/WSEN_PDUS_25131308XXX01.c
@@ -198,7 +198,7 @@ int8_t PDUS_getPressureAndTemperature_float(WE_sensorInterface_t* sensorInterfac
   }
   
   /* Apply temperature offset to raw temperature and convert to °C (0-70°C) */
-  *tempDegC = (((float) (rawTemp - T_MIN_VAL_PDUS) * 4.272) / 1000);
+  *tempDegC = (((float) (rawTemp - T_MIN_VAL_PDUS) * 4.272f) / 1000);
   
   /* Perform conversion regarding sensor sub-type */
   return PDUS_convertPressureToFloat(type, rawPres, presskPa);


### PR DESCRIPTION
C implicit rules will want to make floats into doubles very easily. Some floating constansts were missing the `f` after it make the whole line a double.